### PR TITLE
MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ dist-ssr
 .env
 /build
 /public/build
+/public/images
 /.cache

--- a/app/components/models/canvas/card.tsx
+++ b/app/components/models/canvas/card.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   StackDivider,
   Text,
+  Button,
 } from '~/components';
 import { BuildAttributes } from '~/lib/utils/build-structure/build-attributes';
 import { CanvasDraw } from '~/utils/canvas/draw';
@@ -63,6 +64,15 @@ export const CanvasCard = ({
     );
   };
 
+  const downloadCanvasAsPNG = () => {
+    const canvas = document.getElementById('canvas') as HTMLCanvasElement;
+    const link = document.createElement('a');
+    const timestamp = new Date().getTime();
+    link.download = `canvas_${timestamp}.png`;
+    link.href = canvas.toDataURL();
+    link.click();
+  };
+
   return (
     <Card variant="outline">
       <CardHeader>
@@ -78,6 +88,7 @@ export const CanvasCard = ({
       <CardFooter>
         <Flex width="full">
           <Text>Coming: download</Text>
+          <Button onClick={downloadCanvasAsPNG}>Download PNG</Button>
         </Flex>
       </CardFooter>
     </Card>

--- a/app/components/models/canvas/card.tsx
+++ b/app/components/models/canvas/card.tsx
@@ -87,7 +87,6 @@ export const CanvasCard = ({
       <Divider />
       <CardFooter>
         <Flex width="full">
-          <Text>Coming: download</Text>
           <Button onClick={downloadCanvasAsPNG}>Download PNG</Button>
         </Flex>
       </CardFooter>

--- a/app/routes/dashboard+/generator+/layers+/$layerId.tsx
+++ b/app/routes/dashboard+/generator+/layers+/$layerId.tsx
@@ -61,7 +61,7 @@ export default function LayerDetailsPage() {
 
   return (
     <ColumnContainer>
-      <Column>
+      {/* <Column>
         <LayerCard
           layer={{
             ...layer,
@@ -69,7 +69,7 @@ export default function LayerDetailsPage() {
             updatedAt: new Date(layer.updatedAt),
           }}
         />
-      </Column>
+      </Column> */}
       <Column>
         <CanvasCard
           buildAttributes={buildAttributes ?? {}}

--- a/app/utils/canvas/draw/context.ts
+++ b/app/utils/canvas/draw/context.ts
@@ -1,13 +1,13 @@
 type ContextProps = {
-  context: CanvasRenderingContext2D;
+  ctx: CanvasRenderingContext2D;
 };
 
-export const ContextBegin = ({ context }: ContextProps) => {
-  context.beginPath();
-  context.save();
+export const ContextBegin = ({ ctx }: ContextProps) => {
+  ctx.beginPath();
+  ctx.save();
 };
 
-export const ContextEnd = ({ context }: ContextProps) => {
-  context.restore();
-  context.closePath();
+export const ContextEnd = ({ ctx }: ContextProps) => {
+  ctx.restore();
+  ctx.closePath();
 };

--- a/app/utils/canvas/draw/image.ts
+++ b/app/utils/canvas/draw/image.ts
@@ -28,7 +28,7 @@ type CanvasDrawProps = {
 };
 
 export const CanvasDrawImage = async ({ ctx, dimensions }: CanvasDrawProps) => {
-  const imageSrc = 'http://localhost:5173/images/candy2.png';
+  const imageSrc = 'http://localhost:5173/images/golf5.jpeg';
   const img = await ImageLoad({ imageSrc });
 
   // Get coordinates for image by layout style

--- a/app/utils/canvas/draw/image.ts
+++ b/app/utils/canvas/draw/image.ts
@@ -167,14 +167,14 @@ export const CanvasDrawImage = async ({
   dimensions,
 }: CanvasDrawProps) => {
   const { width, height } = dimensions;
-  const imageSrc = 'http://localhost:5173/images/jack.png';
+  const imageSrc = 'http://localhost:5173/images/pepper.jpeg';
   const img = await ImageLoad({ imageSrc });
 
   // Get coordinates for image by layout style
   const coords = CanvasGetImageCoords({
     canvas,
     img,
-    style: 'stretch-height',
+    style: 'stretch-width',
   });
 
   CanvasDrawImageToContext({ ctx, img, coords });

--- a/app/utils/canvas/draw/image.ts
+++ b/app/utils/canvas/draw/image.ts
@@ -1,0 +1,130 @@
+import { BuildDimensions } from '~/lib/utils/build-structure/build-attributes';
+
+type ImageLoadProps = {
+  imageSrc: string;
+};
+
+export const ImageLoad = async ({
+  imageSrc,
+}: ImageLoadProps): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+
+    img.onload = () => {
+      resolve(img);
+    };
+
+    img.onerror = () => {
+      reject(new Error(`Failed to load image from source: ${imageSrc}`));
+    };
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+    // add this so we can use the image in a canvas
+    // and not get a tainted canvas error
+    img.crossOrigin = 'anonymous';
+
+    img.src = imageSrc;
+  });
+};
+
+type CanvasGetImageCoordsProps = {
+  canvas: HTMLCanvasElement;
+  img: HTMLImageElement;
+  style: 'centered' | 'stretched';
+};
+
+type CanvasDrawImageCoordsMinimalProps = {
+  canvas: HTMLCanvasElement;
+  img: HTMLImageElement;
+};
+
+export type ImageCoords = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+function CanvasDrawImageCoordsCentered({
+  canvas,
+  img,
+}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
+  const xCentered = (canvas.width - img.width) / 2;
+  const yCentered = (canvas.height - img.height) / 2;
+
+  return {
+    x: xCentered,
+    y: yCentered,
+    width: img.width,
+    height: img.height,
+  };
+}
+
+function CanvasDrawImageCoordsStretched({
+  canvas,
+  img,
+}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
+  return {
+    x: 0,
+    y: 0,
+    width: canvas.width,
+    height: canvas.height,
+  };
+}
+
+export function CanvasGetImageCoords({
+  canvas,
+  img,
+  style,
+}: CanvasGetImageCoordsProps): ImageCoords {
+  switch (style) {
+    case 'centered':
+      return CanvasDrawImageCoordsCentered({ canvas, img });
+    case 'stretched':
+    default:
+      return CanvasDrawImageCoordsStretched({ canvas, img });
+  }
+}
+
+type CanvasDrawImageCoordsProps = {
+  ctx: CanvasRenderingContext2D;
+  img: HTMLImageElement;
+  coords: ImageCoords;
+};
+
+export async function CanvasDrawImageToContext({
+  ctx,
+  img,
+  coords,
+}: CanvasDrawImageCoordsProps) {
+  // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
+
+  const { x, y, width, height } = coords;
+  ctx.drawImage(img, x, y, width, height);
+}
+
+type CanvasDrawProps = {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  dimensions: BuildDimensions;
+};
+
+export const CanvasDrawImage = async ({
+  canvas,
+  ctx,
+  dimensions,
+}: CanvasDrawProps) => {
+  const { width, height } = dimensions;
+  const imageSrc = 'http://localhost:5173/images/pepper.jpeg';
+  const img = await ImageLoad({ imageSrc });
+
+  // Get coordinates for image by layout style
+  const coords = CanvasGetImageCoords({
+    canvas,
+    img,
+    style: 'stretched',
+  });
+  console.log('coords', coords);
+
+  CanvasDrawImageToContext({ ctx, img, coords });
+};

--- a/app/utils/canvas/draw/image.ts
+++ b/app/utils/canvas/draw/image.ts
@@ -124,7 +124,6 @@ export const CanvasDrawImage = async ({
     img,
     style: 'stretched',
   });
-  console.log('coords', coords);
 
   CanvasDrawImageToContext({ ctx, img, coords });
 };

--- a/app/utils/canvas/draw/image.ts
+++ b/app/utils/canvas/draw/image.ts
@@ -1,157 +1,23 @@
 import { BuildDimensions } from '~/lib/utils/build-structure/build-attributes';
-
-type ImageLoadProps = {
-  imageSrc: string;
-};
-
-export const ImageLoad = async ({
-  imageSrc,
-}: ImageLoadProps): Promise<HTMLImageElement> => {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-
-    img.onload = () => {
-      resolve(img);
-    };
-
-    img.onerror = () => {
-      reject(new Error(`Failed to load image from source: ${imageSrc}`));
-    };
-
-    // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
-    // add this so we can use the image in a canvas
-    // and not get a tainted canvas error
-    img.crossOrigin = 'anonymous';
-
-    img.src = imageSrc;
-  });
-};
-
-type CanvasGetImageCoordsProps = {
-  canvas: HTMLCanvasElement;
-  img: HTMLImageElement;
-  style: 'centered' | 'stretched' | 'stretch-height' | 'stretch-width';
-};
-
-type CanvasDrawImageCoordsMinimalProps = {
-  canvas: HTMLCanvasElement;
-  img: HTMLImageElement;
-};
-
-export type ImageCoords = {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-};
-
-const ImageSideCenteredInCanvas = (canvasSide: number, imgSide: number) =>
-  (canvasSide - imgSide) / 2;
-
-// place the image as-is in the middle of the canvas
-function CanvasDrawImageCoordsCentered({
-  canvas,
-  img,
-}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
-  const xCentered = ImageSideCenteredInCanvas(canvas.width, img.width);
-  const yCentered = ImageSideCenteredInCanvas(canvas.height, img.height);
-
-  return {
-    x: xCentered,
-    y: yCentered,
-    width: img.width,
-    height: img.height,
-  };
-}
-
-// stretch the image width and height to fit the canvas
-function CanvasDrawImageCoordsStretched({
-  canvas,
-  img,
-}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
-  return {
-    x: 0,
-    y: 0,
-    width: canvas.width,
-    height: canvas.height,
-  };
-}
-
-// stretch the image height to fit the canvas
-// keep the image aspect ratio, and center the image horizontally
-function CanvasDrawImageCoordsStretchImageToCanvasHeight({
-  canvas,
-  img,
-}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
-  // Calculate the aspect ratio of the image.
-  const aspectRatio = img.width / img.height;
-
-  // Calculate the new width of the image based on the canvas height and image aspect ratio.
-  const newWidth = canvas.height * aspectRatio;
-
-  const xCentered = ImageSideCenteredInCanvas(canvas.width, newWidth);
-  return {
-    x: xCentered,
-    y: 0,
-    width: newWidth,
-    height: canvas.height,
-  };
-}
-
-// stretch the image width to fit the canvas
-// keep the image aspect ratio, and center the image vertically
-function CanvasDrawImageCoordsStretchImageToCanvasWidth({
-  canvas,
-  img,
-}: CanvasDrawImageCoordsMinimalProps): ImageCoords {
-  // Calculate the aspect ratio of the image.
-  const aspectRatio = img.width / img.height;
-
-  // Calculate the new height of the image based on the canvas width and image aspect ratio.
-  const newHeight = canvas.width / aspectRatio;
-
-  const yCentered = ImageSideCenteredInCanvas(canvas.height, newHeight);
-  return {
-    x: 0,
-    y: yCentered,
-    width: canvas.width,
-    height: newHeight,
-  };
-}
-
-export function CanvasGetImageCoords({
-  canvas,
-  img,
-  style,
-}: CanvasGetImageCoordsProps): ImageCoords {
-  switch (style) {
-    case 'centered':
-      return CanvasDrawImageCoordsCentered({ canvas, img });
-    case 'stretched':
-      return CanvasDrawImageCoordsStretched({ canvas, img });
-    case 'stretch-height':
-      return CanvasDrawImageCoordsStretchImageToCanvasHeight({ canvas, img });
-    case 'stretch-width':
-      return CanvasDrawImageCoordsStretchImageToCanvasWidth({ canvas, img });
-    default:
-      return CanvasDrawImageCoordsStretched({ canvas, img });
-  }
-}
+import {
+  ImageToCanvasDimensions,
+  ImageCoords,
+} from '~/utils/image-to-canvas-utils';
+import { ImageLoad } from '~/utils/image-utils';
 
 type CanvasDrawImageCoordsProps = {
   ctx: CanvasRenderingContext2D;
   img: HTMLImageElement;
-  coords: ImageCoords;
+  imageDimensions: ImageCoords;
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
 export async function CanvasDrawImageToContext({
   ctx,
   img,
-  coords,
+  imageDimensions,
 }: CanvasDrawImageCoordsProps) {
-  // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-
-  const { x, y, width, height } = coords;
+  const { x, y, width, height } = imageDimensions;
   ctx.drawImage(img, x, y, width, height);
 }
 
@@ -161,21 +27,16 @@ type CanvasDrawProps = {
   dimensions: BuildDimensions;
 };
 
-export const CanvasDrawImage = async ({
-  canvas,
-  ctx,
-  dimensions,
-}: CanvasDrawProps) => {
-  const { width, height } = dimensions;
-  const imageSrc = 'http://localhost:5173/images/pepper.jpeg';
+export const CanvasDrawImage = async ({ ctx, dimensions }: CanvasDrawProps) => {
+  const imageSrc = 'http://localhost:5173/images/candy2.png';
   const img = await ImageLoad({ imageSrc });
 
   // Get coordinates for image by layout style
-  const coords = CanvasGetImageCoords({
-    canvas,
+  const imageDimensions = ImageToCanvasDimensions({
+    dimensions,
     img,
-    style: 'stretch-width',
+    layout: 'stretch-height',
   });
 
-  CanvasDrawImageToContext({ ctx, img, coords });
+  CanvasDrawImageToContext({ ctx, img, imageDimensions });
 };

--- a/app/utils/canvas/draw/index.ts
+++ b/app/utils/canvas/draw/index.ts
@@ -3,6 +3,7 @@ import { CanvasDrawDimensions } from './dimensions';
 import { CanvasDrawBackground } from './background';
 import { BuildAttributes } from '~/lib/utils/build-structure/build-attributes';
 import { CanvasDrawImage } from './image';
+import { CanvasDrawTemplates } from './templates';
 
 type CanvasDrawProps = {
   canvas: HTMLCanvasElement;
@@ -27,4 +28,6 @@ export const CanvasDraw = async ({
   CanvasDrawBackground({ ctx, palette, dimensions });
 
   await CanvasDrawImage({ canvas, ctx, dimensions });
+
+  CanvasDrawTemplates({ ctx, palette, dimensions });
 };

--- a/app/utils/canvas/draw/index.ts
+++ b/app/utils/canvas/draw/index.ts
@@ -2,6 +2,7 @@ import { DesignAttributeWithInputParameters } from '~/utils/canvas-utils';
 import { CanvasDrawDimensions } from './dimensions';
 import { CanvasDrawBackground } from './background';
 import { BuildAttributes } from '~/lib/utils/build-structure/build-attributes';
+import { CanvasDrawImage } from './image';
 
 type CanvasDrawProps = {
   canvas: HTMLCanvasElement;
@@ -9,11 +10,11 @@ type CanvasDrawProps = {
   designAttributes: DesignAttributeWithInputParameters[];
 };
 
-export const CanvasDraw = ({
+export const CanvasDraw = async ({
   canvas,
   buildAttributes,
   designAttributes,
-}: CanvasDrawProps): void => {
+}: CanvasDrawProps) => {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
@@ -24,4 +25,6 @@ export const CanvasDraw = ({
   const { palette } = buildAttributes;
   if (!palette) throw new Error('Palette not found');
   CanvasDrawBackground({ ctx, palette, dimensions });
+
+  await CanvasDrawImage({ canvas, ctx, dimensions });
 };

--- a/app/utils/canvas/draw/index.ts
+++ b/app/utils/canvas/draw/index.ts
@@ -27,7 +27,8 @@ export const CanvasDraw = async ({
   if (!palette) throw new Error('Palette not found');
   CanvasDrawBackground({ ctx, palette, dimensions });
 
-  await CanvasDrawImage({ canvas, ctx, dimensions });
+  // await CanvasDrawImage({ canvas, ctx, dimensions });
 
-  CanvasDrawTemplates({ ctx, palette, dimensions });
+  await CanvasDrawTemplates({ ctx, palette, dimensions });
+  console.log('🏁 done');
 };

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -6,17 +6,14 @@ import { PixelCoordColorHex } from '~/utils/pixel-utils';
 import { CanvasDrawBackground } from './background';
 import { ContextBegin, ContextEnd } from './context';
 import { CanvasDrawTriangleAtCoords } from './triangle';
+import { randomInRange, randomIndex } from '~/utils/random-utils';
 
-const COUNT = 10000;
+const COUNT = 5000;
 
 type CanvasDrawProps = {
   ctx: CanvasRenderingContext2D;
   palette: BuildPalette;
   dimensions: BuildDimensions;
-};
-
-const randomInRange = (min: number, max: number) => {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
 };
 
 export const CanvasDrawTemplates = async ({
@@ -27,13 +24,16 @@ export const CanvasDrawTemplates = async ({
   const { width, height } = dimensions;
 
   const templateBuilds = [];
+  const rotateOptions = [0, 45, 90, 135, 180, 225, 270, 315];
   for (let i = 0; i < COUNT; i++) {
     // the color will be black if the pixel is outside the canvas
     const x = randomInRange(1, width - 1);
     const y = randomInRange(1, height - 1);
     const pixelColor = PixelCoordColorHex({ ctx, x, y });
-    const size = 100;
-    const rotate = (45 / 360) * 2;
+    const size = 50;
+    const index = randomIndex(rotateOptions);
+    const rotation = rotateOptions[index];
+    const rotate = (rotation / 360) * 2;
 
     const templateBuild = {
       x,
@@ -57,7 +57,7 @@ export const CanvasDrawTemplates = async ({
     });
 
     // ctx.fillStyle = pixelColor;
-    ctx.lineWidth = 1;
+    ctx.lineWidth = 3;
     ctx.strokeStyle = pixelColor;
     ctx.stroke();
 

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -4,6 +4,8 @@ import {
 } from '~/lib/utils/build-structure/build-attributes';
 import { PixelCoordColorHex } from '~/utils/pixel-utils';
 import { CanvasDrawBackground } from './background';
+import { ContextBegin, ContextEnd } from './context';
+import { CanvasDrawTriangleAtCoords } from './triangle';
 
 const COUNT = 10000;
 
@@ -30,11 +32,15 @@ export const CanvasDrawTemplates = async ({
     const x = randomInRange(1, width - 1);
     const y = randomInRange(1, height - 1);
     const pixelColor = PixelCoordColorHex({ ctx, x, y });
+    const size = 100;
+    const rotate = (45 / 360) * 2;
 
     const templateBuild = {
       x,
       y,
       pixelColor,
+      size,
+      rotate,
     };
 
     templateBuilds.push(templateBuild);
@@ -43,10 +49,18 @@ export const CanvasDrawTemplates = async ({
   // redraw background to hide image
   CanvasDrawBackground({ ctx, palette, dimensions });
 
-  console.log(templateBuilds);
+  templateBuilds.forEach(({ x, y, pixelColor, size, rotate }) => {
+    ContextBegin({ ctx });
+    CanvasDrawTriangleAtCoords({
+      ctx,
+      triangle: { position: { x, y }, size, rotate },
+    });
 
-  templateBuilds.forEach(({ x, y, pixelColor }) => {
-    ctx.fillStyle = pixelColor;
-    ctx.fillRect(x - 5, y - 5, 10, 10);
+    // ctx.fillStyle = pixelColor;
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = pixelColor;
+    ctx.stroke();
+
+    ContextEnd({ ctx });
   });
 };

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -8,8 +8,11 @@ import { ContextBegin, ContextEnd } from './context';
 import { CanvasDrawTriangleAtCoords } from './triangle';
 import { randomInRange, randomIndex } from '~/utils/random-utils';
 import { adjustColorBrightness, areColorsSimilar } from '~/utils/color-utils';
+import { TemplateLayoutGrid } from '~/utils/template-layout-utils';
 
-const COUNT = 300000;
+const COUNT = 33;
+const ROWS = 33;
+const COLS = 19;
 
 type CanvasDrawProps = {
   ctx: CanvasRenderingContext2D;
@@ -26,103 +29,143 @@ export const CanvasDrawTemplates = async ({
 
   const templateBuilds = [];
   const rotateOptions = [0, 45, 90, 135, 180, 225, 270, 315];
-  // const rotateOptions = [45];
-  for (let i = 0; i < COUNT; i++) {
-    // the color will be black if the pixel is outside the canvas
-    const x = randomInRange(1, width - 1);
-    const y = randomInRange(1, height - 1);
-    const pixelColor = PixelCoordColorHex({ ctx, x, y });
-    const backgroundColor = '#2096f3';
-    // const isBackground =
-    //   pixelColor === backgroundColor ||
-    //   areColorsSimilar(pixelColor, backgroundColor, 0.3) ||
-    //   areColorsSimilar(pixelColor, '#114f7f', 0.13);
 
-    // const isBackground = false;
-    const isBackground =
-      pixelColor === '#000000' ||
-      adjustColorBrightness(pixelColor, 0.5) === '#000000';
+  const defaultLayerProps = {
+    rows: ROWS,
+    cols: COLS,
+    dimensions,
+  };
 
-    let backupPixelColor;
-    if (isBackground) {
-      const backupColors = [
-        '#aa0000',
-        '#075600',
-        '#213c18',
-        '#668c6f',
-        '#378b29',
-        // '#f1e2d0',
-        // '#d8cbbb',
-        // '#f6ede2',
-      ];
-      // backupPixelColor = backupColors[randomIndex(backupColors)];
-      // backupPixelColor = '#FFFFFF';
-      backupPixelColor = '#000000'; // ghost white
-    }
-    // const size = 30;
-    const size = isBackground ? 100 : 5;
-    const index = randomIndex(rotateOptions);
-    const rotation = rotateOptions[index];
-    // const rotation = isBackground ? rotateOptions[index] : 315;
-    // const rotation = isBackground ? 0 : 180;
-    // const rotation = isBackground ? 225 : 0;
-    const rotate = (rotation / 360) * 2;
+  const topLayer3 = TemplateLayoutGrid({
+    ...defaultLayerProps,
+    pixelColor: '#FF5959',
+  });
 
-    const templateBuild = {
-      x,
-      y,
-      pixelColor: backupPixelColor || pixelColor,
-      size,
-      rotate,
-      isBackground,
-    };
+  templateBuilds.push(
+    ...TemplateLayoutGrid({
+      ...defaultLayerProps,
+      pixelColor: '#FFAD5A',
+    })
+  );
+  templateBuilds.push(
+    ...TemplateLayoutGrid({
+      ...defaultLayerProps,
+      pixelColor: '#4F9DA6',
+    })
+  );
+  templateBuilds.push(
+    ...TemplateLayoutGrid({
+      ...defaultLayerProps,
+      pixelColor: '#1A0841',
+    })
+  );
+  // templateBuilds.push(...topLayer3);
 
-    templateBuilds.push(templateBuild);
-  }
+  // // const rotateOptions = [45];
+  // for (let i = 0; i < (ROWS * COLS); i++) {
+  //   // the color will be black if the pixel is outside the canvas
+  //   const x = randomInRange(1, width - 1);
+  //   const y = randomInRange(1, height - 1);
+  //   // faking image pixel color
+  //   const pixelColor = '#000000';
+  //   // const pixelColor = PixelCoordColorHex({ ctx, x, y });
+  //   const backgroundColor = '#2096f3';
+  //   // const isBackground =
+  //   //   pixelColor === backgroundColor ||
+  //   //   areColorsSimilar(pixelColor, backgroundColor, 0.3) ||
+  //   //   areColorsSimilar(pixelColor, '#114f7f', 0.13);
+
+  //   // const isBackground = false;
+  //   const isBackground =
+  //     pixelColor === '#FFFFFF' ||
+  //     adjustColorBrightness(pixelColor, 0.5) === '#FFFFFF';
+
+  //   let backupPixelColor;
+  //   if (isBackground) {
+  //     const backupColors = [
+  //       '#aa0000',
+  //       '#075600',
+  //       '#213c18',
+  //       '#668c6f',
+  //       '#378b29',
+  //       // '#f1e2d0',
+  //       // '#d8cbbb',
+  //       // '#f6ede2',
+  //     ];
+  //     // backupPixelColor = backupColors[randomIndex(backupColors)];
+  //     // backupPixelColor = '#FFFFFF';
+  //     backupPixelColor = '#000000'; // ghost white
+  //   }
+  //   // const size = 30;
+  //   const sizeMultiplier = 3;
+  //   const sizePercent = 0.1;
+  //   const canvasWidth = width;
+  //   const size = canvasWidth * sizePercent * sizeMultiplier;
+  //   // const size = isBackground ? 100 : size;
+  //   const index = randomIndex(rotateOptions);
+  //   const rotation = rotateOptions[index];
+  //   // const rotation = isBackground ? rotateOptions[index] : 315;
+  //   // const rotation = isBackground ? 0 : 180;
+  //   // const rotation = isBackground ? 225 : 0;
+  //   const rotate = (rotation / 360) * 2;
+
+  //   const templateBuild = {
+  //     x,
+  //     y,
+  //     pixelColor: backupPixelColor || pixelColor,
+  //     size,
+  //     rotate,
+  //     isBackground,
+  //   };
+
+  //   templateBuilds.push(templateBuild);
+  // }
 
   // redraw background to hide image
-  CanvasDrawBackground({ ctx, palette, dimensions });
+  // CanvasDrawBackground({ ctx, palette, dimensions });
 
   templateBuilds.forEach(
     ({ x, y, pixelColor, size, rotate, isBackground }, i) => {
       ContextBegin({ ctx });
 
-      // Adjust size randomly within a range of a customizable percentage bigger or smaller
-      const percentage = 7.9; // customize this value as needed
-      const adjustment = Math.random() * 2 * percentage - percentage; // random number between -percentage and percentage
-      // size = size * (1 + adjustment);
-      size = isBackground ? 1 : size * (1 + adjustment);
+      // // Adjust size randomly within a range of a customizable percentage bigger or smaller
+      // const percentage = 1.5; // customize this value as needed
+      // const adjustment = Math.random() * 2 * percentage - percentage; // random number between -percentage and percentage
+      // // size = size * (1 + adjustment);
+      // size = isBackground ? 1 : size * (1 + adjustment);
 
       // rotate = i % 2 === 0 ? rotate : 1;
+      // rotate = i % 2 === 0 ? 1.5 : 0.5;
 
       CanvasDrawTriangleAtCoords({
         ctx,
         triangle: { position: { x, y }, size, rotate },
       });
 
-      const fillPixelColorAdjusted = adjustColorBrightness(pixelColor, -0.31);
+      // const fillPixelColorAdjusted = adjustColorBrightness(pixelColor, -0.31);
 
-      // ctx.fillStyle = pixelColor;
-      ctx.fillStyle = fillPixelColorAdjusted;
+      ctx.fillStyle = pixelColor;
+      // ctx.fillStyle = fillPixelColorAdjusted;
       if (isBackground) {
         // const xmasColors = ['#f00', '#0f0'];
         // const xmasColor = xmasColors[randomIndex(xmasColors)];
         // ctx.fillStyle = xmascolor;
         // ctx.fill();
-      } else if (i % 3 === 0) {
+      } else if (i % 9 === 0) {
         ctx.fill();
       }
       // ctx.fill();
 
       // ctx.lineWidth = 2;
-      ctx.lineWidth = isBackground ? 6 : 1;
+      ctx.lineWidth = isBackground ? 6 : 3;
 
-      const strokePixelColorAdjusted = adjustColorBrightness(
-        pixelColor,
-        -0.231
-      );
+      // const strokePixelColorAdjusted = adjustColorBrightness(
+      //   pixelColor,
+      //   -0.231
+      // );
 
-      ctx.strokeStyle = strokePixelColorAdjusted;
+      ctx.strokeStyle = pixelColor;
+      // ctx.strokeStyle = strokePixelColorAdjusted;
       ctx.stroke();
 
       ContextEnd({ ctx });

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -7,8 +7,9 @@ import { CanvasDrawBackground } from './background';
 import { ContextBegin, ContextEnd } from './context';
 import { CanvasDrawTriangleAtCoords } from './triangle';
 import { randomInRange, randomIndex } from '~/utils/random-utils';
+import { adjustColorBrightness } from '~/utils/color-utils';
 
-const COUNT = 5000;
+const COUNT = 100000;
 
 type CanvasDrawProps = {
   ctx: CanvasRenderingContext2D;
@@ -25,22 +26,44 @@ export const CanvasDrawTemplates = async ({
 
   const templateBuilds = [];
   const rotateOptions = [0, 45, 90, 135, 180, 225, 270, 315];
+  // const rotateOptions = [45];
   for (let i = 0; i < COUNT; i++) {
     // the color will be black if the pixel is outside the canvas
     const x = randomInRange(1, width - 1);
     const y = randomInRange(1, height - 1);
     const pixelColor = PixelCoordColorHex({ ctx, x, y });
-    const size = 50;
+    const isBackground =
+      pixelColor === '#FFFFFF' ||
+      adjustColorBrightness(pixelColor, 0.5) === '#FFFFFF';
+
+    let backupPixelColor;
+    if (isBackground) {
+      // const backupColors = [
+      //   '#f1e2d0',
+      //   '#d8cbbb',
+      //   '#f6ede2',
+      //   // '#c0b4a6',
+      //   // '#a89e91',
+      //   // '#90877c',
+      // ];
+      // backupPixelColor = backupColors[randomIndex(backupColors)];
+      backupPixelColor = '#f1e2d0';
+    }
+    // const size = 30;
+    const size = isBackground ? 30 : 30;
     const index = randomIndex(rotateOptions);
-    const rotation = rotateOptions[index];
+    // const rotation = rotateOptions[index];
+    const rotation = isBackground ? rotateOptions[index] : 315;
+    // const rotation = isBackground ? 225 : 45;
     const rotate = (rotation / 360) * 2;
 
     const templateBuild = {
       x,
       y,
-      pixelColor,
+      pixelColor: backupPixelColor || pixelColor,
       size,
       rotate,
+      isBackground,
     };
 
     templateBuilds.push(templateBuild);
@@ -49,18 +72,29 @@ export const CanvasDrawTemplates = async ({
   // redraw background to hide image
   CanvasDrawBackground({ ctx, palette, dimensions });
 
-  templateBuilds.forEach(({ x, y, pixelColor, size, rotate }) => {
-    ContextBegin({ ctx });
-    CanvasDrawTriangleAtCoords({
-      ctx,
-      triangle: { position: { x, y }, size, rotate },
-    });
+  templateBuilds.forEach(
+    ({ x, y, pixelColor, size, rotate, isBackground }, i) => {
+      ContextBegin({ ctx });
+      CanvasDrawTriangleAtCoords({
+        ctx,
+        triangle: { position: { x, y }, size, rotate },
+      });
 
-    // ctx.fillStyle = pixelColor;
-    ctx.lineWidth = 3;
-    ctx.strokeStyle = pixelColor;
-    ctx.stroke();
+      ctx.fillStyle = pixelColor;
+      if (isBackground) {
+        ctx.fill();
+      } else if (i % 3 === 0) {
+        ctx.fill();
+      }
+      // ctx.lineWidth = 2;
+      ctx.lineWidth = isBackground ? 2 : 1;
 
-    ContextEnd({ ctx });
-  });
+      const pixelColorAdjusted = adjustColorBrightness(pixelColor, -0.1);
+
+      ctx.strokeStyle = pixelColorAdjusted;
+      ctx.stroke();
+
+      ContextEnd({ ctx });
+    }
+  );
 };

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -1,0 +1,52 @@
+import {
+  BuildDimensions,
+  BuildPalette,
+} from '~/lib/utils/build-structure/build-attributes';
+import { PixelCoordColorHex } from '~/utils/pixel-utils';
+import { CanvasDrawBackground } from './background';
+
+const COUNT = 10000;
+
+type CanvasDrawProps = {
+  ctx: CanvasRenderingContext2D;
+  palette: BuildPalette;
+  dimensions: BuildDimensions;
+};
+
+const randomInRange = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+export const CanvasDrawTemplates = async ({
+  ctx,
+  palette,
+  dimensions,
+}: CanvasDrawProps) => {
+  const { width, height } = dimensions;
+
+  const templateBuilds = [];
+  for (let i = 0; i < COUNT; i++) {
+    // the color will be black if the pixel is outside the canvas
+    const x = randomInRange(1, width - 1);
+    const y = randomInRange(1, height - 1);
+    const pixelColor = PixelCoordColorHex({ ctx, x, y });
+
+    const templateBuild = {
+      x,
+      y,
+      pixelColor,
+    };
+
+    templateBuilds.push(templateBuild);
+  }
+
+  // redraw background to hide image
+  CanvasDrawBackground({ ctx, palette, dimensions });
+
+  console.log(templateBuilds);
+
+  templateBuilds.forEach(({ x, y, pixelColor }) => {
+    ctx.fillStyle = pixelColor;
+    ctx.fillRect(x - 5, y - 5, 10, 10);
+  });
+};

--- a/app/utils/canvas/draw/templates.ts
+++ b/app/utils/canvas/draw/templates.ts
@@ -7,9 +7,9 @@ import { CanvasDrawBackground } from './background';
 import { ContextBegin, ContextEnd } from './context';
 import { CanvasDrawTriangleAtCoords } from './triangle';
 import { randomInRange, randomIndex } from '~/utils/random-utils';
-import { adjustColorBrightness } from '~/utils/color-utils';
+import { adjustColorBrightness, areColorsSimilar } from '~/utils/color-utils';
 
-const COUNT = 100000;
+const COUNT = 300000;
 
 type CanvasDrawProps = {
   ctx: CanvasRenderingContext2D;
@@ -32,29 +32,40 @@ export const CanvasDrawTemplates = async ({
     const x = randomInRange(1, width - 1);
     const y = randomInRange(1, height - 1);
     const pixelColor = PixelCoordColorHex({ ctx, x, y });
+    const backgroundColor = '#2096f3';
+    // const isBackground =
+    //   pixelColor === backgroundColor ||
+    //   areColorsSimilar(pixelColor, backgroundColor, 0.3) ||
+    //   areColorsSimilar(pixelColor, '#114f7f', 0.13);
+
+    // const isBackground = false;
     const isBackground =
-      pixelColor === '#FFFFFF' ||
-      adjustColorBrightness(pixelColor, 0.5) === '#FFFFFF';
+      pixelColor === '#000000' ||
+      adjustColorBrightness(pixelColor, 0.5) === '#000000';
 
     let backupPixelColor;
     if (isBackground) {
-      // const backupColors = [
-      //   '#f1e2d0',
-      //   '#d8cbbb',
-      //   '#f6ede2',
-      //   // '#c0b4a6',
-      //   // '#a89e91',
-      //   // '#90877c',
-      // ];
+      const backupColors = [
+        '#aa0000',
+        '#075600',
+        '#213c18',
+        '#668c6f',
+        '#378b29',
+        // '#f1e2d0',
+        // '#d8cbbb',
+        // '#f6ede2',
+      ];
       // backupPixelColor = backupColors[randomIndex(backupColors)];
-      backupPixelColor = '#f1e2d0';
+      // backupPixelColor = '#FFFFFF';
+      backupPixelColor = '#000000'; // ghost white
     }
     // const size = 30;
-    const size = isBackground ? 30 : 30;
+    const size = isBackground ? 100 : 5;
     const index = randomIndex(rotateOptions);
-    // const rotation = rotateOptions[index];
-    const rotation = isBackground ? rotateOptions[index] : 315;
-    // const rotation = isBackground ? 225 : 45;
+    const rotation = rotateOptions[index];
+    // const rotation = isBackground ? rotateOptions[index] : 315;
+    // const rotation = isBackground ? 0 : 180;
+    // const rotation = isBackground ? 225 : 0;
     const rotate = (rotation / 360) * 2;
 
     const templateBuild = {
@@ -75,23 +86,43 @@ export const CanvasDrawTemplates = async ({
   templateBuilds.forEach(
     ({ x, y, pixelColor, size, rotate, isBackground }, i) => {
       ContextBegin({ ctx });
+
+      // Adjust size randomly within a range of a customizable percentage bigger or smaller
+      const percentage = 7.9; // customize this value as needed
+      const adjustment = Math.random() * 2 * percentage - percentage; // random number between -percentage and percentage
+      // size = size * (1 + adjustment);
+      size = isBackground ? 1 : size * (1 + adjustment);
+
+      // rotate = i % 2 === 0 ? rotate : 1;
+
       CanvasDrawTriangleAtCoords({
         ctx,
         triangle: { position: { x, y }, size, rotate },
       });
 
-      ctx.fillStyle = pixelColor;
+      const fillPixelColorAdjusted = adjustColorBrightness(pixelColor, -0.31);
+
+      // ctx.fillStyle = pixelColor;
+      ctx.fillStyle = fillPixelColorAdjusted;
       if (isBackground) {
-        ctx.fill();
+        // const xmasColors = ['#f00', '#0f0'];
+        // const xmasColor = xmasColors[randomIndex(xmasColors)];
+        // ctx.fillStyle = xmascolor;
+        // ctx.fill();
       } else if (i % 3 === 0) {
         ctx.fill();
       }
+      // ctx.fill();
+
       // ctx.lineWidth = 2;
-      ctx.lineWidth = isBackground ? 2 : 1;
+      ctx.lineWidth = isBackground ? 6 : 1;
 
-      const pixelColorAdjusted = adjustColorBrightness(pixelColor, -0.1);
+      const strokePixelColorAdjusted = adjustColorBrightness(
+        pixelColor,
+        -0.231
+      );
 
-      ctx.strokeStyle = pixelColorAdjusted;
+      ctx.strokeStyle = strokePixelColorAdjusted;
       ctx.stroke();
 
       ContextEnd({ ctx });

--- a/app/utils/canvas/draw/triangle.ts
+++ b/app/utils/canvas/draw/triangle.ts
@@ -1,0 +1,99 @@
+type CanvasDrawProps = {
+  ctx: CanvasRenderingContext2D;
+  triangle: {
+    position: { x: number; y: number };
+    size: number;
+    rotate: number;
+  };
+};
+
+// https://byjus.com/question-answer/if-an-equilateral-triangle-is-drawn-inside-a-circle-such-that-the-circle-is-the/
+const getRadius = (size: number) => {
+  return size / Math.sqrt(3);
+};
+
+const setContextPosition = ({
+  ctx,
+  position,
+}: {
+  ctx: CanvasRenderingContext2D;
+  position: { x: number; y: number };
+}) => {
+  const { x, y } = position;
+  ctx.translate(x, y);
+};
+
+// this starts the path at 0, 0
+// commenting out because we want the line to start at the top, not center
+// keeping for debugger reference if I ever want to see where the middle point is landing
+const startFromPosition = ({
+  ctx,
+  size,
+}: {
+  ctx: CanvasRenderingContext2D;
+  size: number;
+}) => {
+  // uncomment to display lines from center
+  // ctx.moveTo(0, 0);
+};
+
+// rotate moved ctx at new 0, 0 position
+const setContextRotate = ({
+  ctx,
+  rotate,
+}: {
+  ctx: CanvasRenderingContext2D;
+  rotate: number;
+}) => {
+  ctx.rotate(Math.PI * rotate);
+};
+
+const drawLines = ({
+  ctx,
+  radius,
+  inset,
+  points,
+}: {
+  ctx: CanvasRenderingContext2D;
+  radius: number;
+  inset: number;
+  points: number;
+}) => {
+  // top middle
+  ctx.lineTo(0, 0 - radius);
+  ctx.rotate(Math.PI / points);
+  ctx.lineTo(0, 0 - radius * inset);
+  ctx.rotate(Math.PI / points);
+
+  // bottom right
+  ctx.lineTo(0, 0 - radius);
+  ctx.rotate(Math.PI / points);
+  ctx.lineTo(0, 0 - radius * inset);
+  ctx.rotate(Math.PI / points);
+
+  // bottom left
+  ctx.lineTo(0, 0 - radius);
+  ctx.rotate(Math.PI / points);
+  ctx.lineTo(0, 0 - radius * inset);
+  ctx.rotate(Math.PI / points);
+
+  // closes the path back to the top middle
+  ctx.closePath();
+};
+
+export function CanvasDrawTriangleAtCoords({ ctx, triangle }: CanvasDrawProps) {
+  const { position, size, rotate } = triangle;
+
+  // 0.5 inset creates a flat line
+  // greater will bow out
+  // less will bow in
+  // current settings are for a perfect triangle
+  const inset = 0.5;
+  const points = 3;
+
+  const radius = getRadius(size);
+  setContextPosition({ ctx, position });
+  startFromPosition({ ctx, size });
+  setContextRotate({ ctx, rotate });
+  drawLines({ ctx, radius, inset, points });
+}

--- a/app/utils/color-utils.ts
+++ b/app/utils/color-utils.ts
@@ -23,3 +23,29 @@ export const colorRandomHex = (): string => {
   }
   return `#${random.toUpperCase()}`;
 };
+
+export const adjustColorBrightness = (
+  hex: string,
+  percentage: number
+): string => {
+  hex = hex.replace('#', '');
+
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+
+  const rAdj = Math.min(Math.max(Math.round(r * (1 + percentage)), 0), 255)
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase();
+  const gAdj = Math.min(Math.max(Math.round(g * (1 + percentage)), 0), 255)
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase();
+  const bAdj = Math.min(Math.max(Math.round(b * (1 + percentage)), 0), 255)
+    .toString(16)
+    .padStart(2, '0')
+    .toUpperCase();
+
+  return `#${rAdj}${gAdj}${bAdj}`;
+};

--- a/app/utils/color-utils.ts
+++ b/app/utils/color-utils.ts
@@ -49,3 +49,26 @@ export const adjustColorBrightness = (
 
   return `#${rAdj}${gAdj}${bAdj}`;
 };
+
+export const areColorsSimilar = (
+  hex1: string,
+  hex2: string,
+  sameness: number = 0.1
+): boolean => {
+  // Convert hex to RGB
+  const r1 = parseInt(hex1.substring(1, 3), 16);
+  const g1 = parseInt(hex1.substring(3, 5), 16);
+  const b1 = parseInt(hex1.substring(5, 7), 16);
+
+  const r2 = parseInt(hex2.substring(1, 3), 16);
+  const g2 = parseInt(hex2.substring(3, 5), 16);
+  const b2 = parseInt(hex2.substring(5, 7), 16);
+
+  // Calculate the difference
+  const diffR = Math.abs(r1 - r2) / 255;
+  const diffG = Math.abs(g1 - g2) / 255;
+  const diffB = Math.abs(b1 - b2) / 255;
+
+  // Check if the colors are similar
+  return diffR <= sameness && diffG <= sameness && diffB <= sameness;
+};

--- a/app/utils/image-to-canvas-utils.ts
+++ b/app/utils/image-to-canvas-utils.ts
@@ -1,0 +1,116 @@
+import { BuildDimensions } from '~/lib/utils/build-structure/build-attributes';
+
+type CanvasGetImageCoordsProps = {
+  dimensions: BuildDimensions;
+  img: HTMLImageElement;
+  layout: 'centered' | 'stretched' | 'stretch-height' | 'stretch-width';
+};
+
+type ImageToCanvasMinimalProps = {
+  dimensions: BuildDimensions;
+  img: HTMLImageElement;
+};
+
+export type ImageCoords = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+const ImageSideCenteredInCanvas = (canvasSide: number, imgSide: number) =>
+  (canvasSide - imgSide) / 2;
+
+// place the image as-is in the middle of the canvas
+function ImageToCanvasCentered({
+  dimensions,
+  img,
+}: ImageToCanvasMinimalProps): ImageCoords {
+  const { width, height } = dimensions;
+  const xCentered = ImageSideCenteredInCanvas(width, img.width);
+  const yCentered = ImageSideCenteredInCanvas(height, img.height);
+
+  return {
+    x: xCentered,
+    y: yCentered,
+    width: img.width,
+    height: img.height,
+  };
+}
+
+// stretch the image width and height to fit the canvas
+function ImageToCanvasStretched({
+  dimensions,
+}: ImageToCanvasMinimalProps): ImageCoords {
+  const { width, height } = dimensions;
+  return {
+    x: 0,
+    y: 0,
+    width: width,
+    height: height,
+  };
+}
+
+// stretch the image height to fit the canvas
+// keep the image aspect ratio, and center the image horizontally
+function ImageToCanvasStretchHeight({
+  dimensions,
+  img,
+}: ImageToCanvasMinimalProps): ImageCoords {
+  const { width, height } = dimensions;
+  // Calculate the aspect ratio of the image.
+  const aspectRatio = img.width / img.height;
+
+  // Calculate the new width of the image based on the canvas height and image aspect ratio.
+  const newWidth = height * aspectRatio;
+
+  const xCentered = ImageSideCenteredInCanvas(width, newWidth);
+  return {
+    x: xCentered,
+    y: 0,
+    width: newWidth,
+    height: height,
+  };
+}
+
+// stretch the image width to fit the canvas
+// keep the image aspect ratio, and center the image vertically
+function ImageToCanvasStretchWidth({
+  dimensions,
+  img,
+}: ImageToCanvasMinimalProps): ImageCoords {
+  const { width, height } = dimensions;
+
+  // Calculate the aspect ratio of the image.
+  const aspectRatio = img.width / img.height;
+
+  // Calculate the new height of the image based on the canvas width and image aspect ratio.
+  const newHeight = width / aspectRatio;
+
+  const yCentered = ImageSideCenteredInCanvas(height, newHeight);
+  return {
+    x: 0,
+    y: yCentered,
+    width: width,
+    height: newHeight,
+  };
+}
+
+export function ImageToCanvasDimensions({
+  dimensions,
+  img,
+  layout,
+}: CanvasGetImageCoordsProps): ImageCoords {
+  switch (layout) {
+    case 'centered':
+      return ImageToCanvasCentered({ dimensions, img });
+    case 'stretched':
+      return ImageToCanvasStretched({ dimensions, img });
+    case 'stretch-height':
+      return ImageToCanvasStretchHeight({ dimensions, img });
+    case 'stretch-width':
+      return ImageToCanvasStretchWidth({ dimensions, img });
+    default:
+      return ImageToCanvasStretched({ dimensions, img });
+  }
+}

--- a/app/utils/image-utils.ts
+++ b/app/utils/image-utils.ts
@@ -1,0 +1,26 @@
+type ImageLoadProps = {
+  imageSrc: string;
+};
+
+export const ImageLoad = async ({
+  imageSrc,
+}: ImageLoadProps): Promise<HTMLImageElement> => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+
+    img.onload = () => {
+      resolve(img);
+    };
+
+    img.onerror = () => {
+      reject(new Error(`Failed to load image from source: ${imageSrc}`));
+    };
+
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+    // add this so we can use the image in a canvas
+    // and not get a tainted canvas error
+    img.crossOrigin = 'anonymous';
+
+    img.src = imageSrc;
+  });
+};

--- a/app/utils/pixel-utils.ts
+++ b/app/utils/pixel-utils.ts
@@ -1,0 +1,39 @@
+type PixelCoordColorHexProps = {
+  ctx: CanvasRenderingContext2D;
+  x: number;
+  y: number;
+};
+
+export const PixelCoordColorHex = ({ ctx, x, y }: PixelCoordColorHexProps) => {
+  const pixelData = buildPixelImageData({ ctx, x, y });
+  const { r, g, b } = buildPixelRGB({ data: pixelData.data });
+  const hex = '#' + componentToHex(r) + componentToHex(g) + componentToHex(b);
+  return hex.toUpperCase();
+};
+
+const buildPixelImageData = ({
+  ctx,
+  x,
+  y,
+}: PixelCoordColorHexProps): ImageData => {
+  return ctx.getImageData(x, y, 1, 1);
+};
+
+type PixelRGBProps = {
+  data: Uint8ClampedArray;
+};
+
+const buildPixelRGB = ({ data }: PixelRGBProps) => {
+  const r = data[0];
+  const g = data[1];
+  const b = data[2];
+  return { r, g, b };
+};
+
+// To convert the color values to a hex string, you can use the following function:
+// idk chat gpt came up with this and it works
+// investigate later if this is acting weird bc I've done this before
+function componentToHex(c: number) {
+  const hex = c.toString(16);
+  return hex.length == 1 ? '0' + hex : hex;
+}

--- a/app/utils/random-utils.ts
+++ b/app/utils/random-utils.ts
@@ -1,0 +1,7 @@
+export const randomInRange = (min: number, max: number) => {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+};
+
+export const randomIndex = (array: any) => {
+  return Math.floor(Math.random() * array.length);
+};

--- a/app/utils/rotate-utils.ts
+++ b/app/utils/rotate-utils.ts
@@ -1,0 +1,8 @@
+import { randomInRange } from './random-utils';
+
+// Math.PI / 1 = 180 degrees
+export const RotateCompass = () => {
+  return [0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75];
+};
+
+export const RotateRandom = () => randomInRange(0, 2);

--- a/app/utils/template-layout-utils.ts
+++ b/app/utils/template-layout-utils.ts
@@ -1,0 +1,66 @@
+import { BuildDimensions } from '~/lib/utils/build-structure/build-attributes';
+import { RotateCompass } from './rotate-utils';
+import { randomIndex } from './random-utils';
+import { colorRandomHex } from './color-utils';
+
+type TemplateLayoutGridProps = {
+  cols: number;
+  rows: number;
+  dimensions: BuildDimensions;
+  pixelColor?: string;
+};
+
+type TemplateBuildProps = {
+  x: number;
+  y: number;
+  pixelColor: string;
+  size: number;
+  rotate: number;
+  isBackground: boolean;
+};
+
+export const TemplateLayoutGrid = ({
+  rows,
+  cols,
+  dimensions,
+  pixelColor,
+}: TemplateLayoutGridProps): TemplateBuildProps[] => {
+  const { width, height } = dimensions;
+
+  // Calculate the step size for x and y
+  const xStep = width / cols;
+  const yStep = height / rows;
+
+  const rotateOptions = RotateCompass();
+  const templateBuilds: TemplateBuildProps[] = [];
+
+  for (let row = 0; row < rows; row++) {
+    for (let col = 0; col < cols; col++) {
+      // Calculate x and y for the current position
+      const x = col * xStep + xStep / 2; // center in cell
+      const y = row * yStep + yStep / 2; // center in cell
+
+      const sizeMultiplier = 1;
+      const sizePercent = 0.1;
+      const canvasWidth = width;
+      const size = canvasWidth * sizePercent * sizeMultiplier;
+
+      const index = randomIndex(rotateOptions);
+      const rotate = rotateOptions[index];
+
+      const templateBuild = {
+        x,
+        y,
+        pixelColor: pixelColor || colorRandomHex(),
+        size,
+        rotate: 0.25,
+        // rotate,
+        isBackground: false,
+      };
+
+      templateBuilds.push(templateBuild);
+    }
+  }
+
+  return templateBuilds;
+};

--- a/app/utils/types/input-parameter/palette.ts
+++ b/app/utils/types/input-parameter/palette.ts
@@ -42,7 +42,7 @@ export type InputParameterPaletteType = {
 };
 
 export const defaultPaletteColors = [
-  '#835a3d',
+  '#fff',
   '#FF5959',
   '#FFAD5A',
   '#4F9DA6',

--- a/app/utils/types/input-parameter/palette.ts
+++ b/app/utils/types/input-parameter/palette.ts
@@ -42,7 +42,7 @@ export type InputParameterPaletteType = {
 };
 
 export const defaultPaletteColors = [
-  '#fff',
+  '#0f181c',
   '#FF5959',
   '#FFAD5A',
   '#4F9DA6',

--- a/app/utils/types/input-parameter/palette.ts
+++ b/app/utils/types/input-parameter/palette.ts
@@ -41,8 +41,8 @@ export type InputParameterPaletteType = {
   rangeValues: InputParameterPaletteRangeValuesType;
 };
 
+// first color is canvas background as of this commit
 export const defaultPaletteColors = [
-  '#0f181c',
   '#FF5959',
   '#FFAD5A',
   '#4F9DA6',

--- a/app/utils/types/input-parameter/palette.ts
+++ b/app/utils/types/input-parameter/palette.ts
@@ -42,6 +42,7 @@ export type InputParameterPaletteType = {
 };
 
 export const defaultPaletteColors = [
+  '#835a3d',
   '#FF5959',
   '#FFAD5A',
   '#4F9DA6',

--- a/prisma/seed-create.ts
+++ b/prisma/seed-create.ts
@@ -322,12 +322,18 @@ export const seedDesignAttributesOnLayers = async () => {
   // update layer build attributes for palette
   const buildAttributes = (layer.buildAttributes || {}) as BuildAttributes;
 
-  // https://www.docucopies.com/image-resolution/#:~:text=How%20many%20pixels%20is%208.5,artwork%20at%203400px%20x%204400px.
+  // https://shotkit.com/how-big-is-a-4x6-photo/
   const buildDimensions: BuildDimensions = {
-    width: 2550,
-    height: 3300,
+    width: 1800,
+    height: 1200,
     format: 'px',
   };
+  // // https://www.docucopies.com/image-resolution/#:~:text=How%20many%20pixels%20is%208.5,artwork%20at%203400px%20x%204400px.
+  // const buildDimensions: BuildDimensions = {
+  //   width: 255 * 10,
+  //   height: 330 * 10,
+  //   format: 'px',
+  // };
   const buildPalette: BuildPalette = {
     colors: defaultPaletteColors,
     format: 'hex',

--- a/prisma/seed-create.ts
+++ b/prisma/seed-create.ts
@@ -322,12 +322,32 @@ export const seedDesignAttributesOnLayers = async () => {
   // update layer build attributes for palette
   const buildAttributes = (layer.buildAttributes || {}) as BuildAttributes;
 
-  // https://shotkit.com/how-big-is-a-4x6-photo/
+  // IG Story 9:16
+  // const buildDimensions: BuildDimensions = {
+  //   width: 1080,
+  //   height: 1920,
+  //   format: 'px',
+  // };
+  // 16:9
+  // const buildDimensions: BuildDimensions = {
+  //   width: 1920,
+  //   height: 1080,
+  //   format: 'px',
+  // };
+
+  // 4:3
   const buildDimensions: BuildDimensions = {
-    width: 1800,
-    height: 1200,
+    width: 2400,
+    height: 1800,
     format: 'px',
   };
+
+  // // https://shotkit.com/how-big-is-a-4x6-photo/
+  // const buildDimensions: BuildDimensions = {
+  //   width: 1800,
+  //   height: 1200,
+  //   format: 'px',
+  // };
   // // https://www.docucopies.com/image-resolution/#:~:text=How%20many%20pixels%20is%208.5,artwork%20at%203400px%20x%204400px.
   // const buildDimensions: BuildDimensions = {
   //   width: 255 * 10,

--- a/prisma/seed-create.ts
+++ b/prisma/seed-create.ts
@@ -323,11 +323,11 @@ export const seedDesignAttributesOnLayers = async () => {
   const buildAttributes = (layer.buildAttributes || {}) as BuildAttributes;
 
   // IG Story 9:16
-  // const buildDimensions: BuildDimensions = {
-  //   width: 1080,
-  //   height: 1920,
-  //   format: 'px',
-  // };
+  const buildDimensions: BuildDimensions = {
+    width: 1080,
+    height: 1920,
+    format: 'px',
+  };
   // 16:9
   // const buildDimensions: BuildDimensions = {
   //   width: 1920,
@@ -336,11 +336,18 @@ export const seedDesignAttributesOnLayers = async () => {
   // };
 
   // 4:3
-  const buildDimensions: BuildDimensions = {
-    width: 2400,
-    height: 1800,
-    format: 'px',
-  };
+  // const buildDimensions: BuildDimensions = {
+  //   width: 2400,
+  //   height: 1800,
+  //   format: 'px',
+  // };
+
+  // 8.5 x 11
+  // const buildDimensions: BuildDimensions = {
+  //   width: 2550,
+  //   height: 3300,
+  //   format: 'px',
+  // };
 
   // // https://shotkit.com/how-big-is-a-4x6-photo/
   // const buildDimensions: BuildDimensions = {

--- a/prisma/seed-create.ts
+++ b/prisma/seed-create.ts
@@ -322,9 +322,10 @@ export const seedDesignAttributesOnLayers = async () => {
   // update layer build attributes for palette
   const buildAttributes = (layer.buildAttributes || {}) as BuildAttributes;
 
+  // https://www.docucopies.com/image-resolution/#:~:text=How%20many%20pixels%20is%208.5,artwork%20at%203400px%20x%204400px.
   const buildDimensions: BuildDimensions = {
-    width: 1000,
-    height: 1000,
+    width: 255,
+    height: 330,
     format: 'px',
   };
   const buildPalette: BuildPalette = {

--- a/prisma/seed-create.ts
+++ b/prisma/seed-create.ts
@@ -324,8 +324,8 @@ export const seedDesignAttributesOnLayers = async () => {
 
   // https://www.docucopies.com/image-resolution/#:~:text=How%20many%20pixels%20is%208.5,artwork%20at%203400px%20x%204400px.
   const buildDimensions: BuildDimensions = {
-    width: 255,
-    height: 330,
+    width: 2550,
+    height: 3300,
     format: 'px',
   };
   const buildPalette: BuildPalette = {


### PR DESCRIPTION
A hacked MVP to demo the template triangles in time for the holidays and produce some visually appealing outputs

Features added:
- draw image to canvas
- get pixel color from random x, y coordinates
- draw triangles at each x, y with a fillStyle, strokeStyle, lineWidth, size
- download the canvas to png
- can customize rotations of each triangle
- color util to reset fill/stroke style color by adjusting brightness/darkness of pixel color
- compare sameness of colors to smooth edges of cropped out background images (*explanation below)
- can set image layout on canvas: centered, stretched, stretch to height/width (keep aspect ratio)
- can choose to add build templates from a grid layout (**explanation below)

Explanation 1: 
I use [remove bg](https://www.remove.bg/) to crop out the background of some images and turn the subject into triangles. When I download the finished product I make sure it has a white background, or sometimes another color. This way I can detect white pixels and declare them as the background before the build gets drawn. Sometimes the app will have a little white around the edges. I can adjust the pixel color at the given x, y in the loop and brighten it 10%, for example, and if it's #FFFFFF then I can declare it is also a part of the background. Making big triangles out of tiny pixels will make these errors in the cropping by "remove bg" more obvious so this feature is very useful!

Explanation 2:
I have historically just let the randomness of pixels in the canvas form the composition of my art in past apps that I've built. This is the beginning of a grid layout option. I will definitely need to refactor this code and also create another function for randomness.